### PR TITLE
Date range fields

### DIFF
--- a/search.go
+++ b/search.go
@@ -28,9 +28,9 @@ type TextField struct {
 
 type RangeField struct {
 	XMLName xml.Name
-	Is      float64 `xml:"is,omitempty"`
-	Min     float64 `xml:"min,omitempty"`
-	Max     float64 `xml:"max,omitempty"`
+	Is      interface{} `xml:"is,omitempty"`
+	Min     interface{} `xml:"min,omitempty"`
+	Max     interface{} `xml:"max,omitempty"`
 }
 
 type MultiField struct {

--- a/search_test.go
+++ b/search_test.go
@@ -20,10 +20,47 @@ func TestSearchXMLEncode(t *testing.T) {
 	f2.Min = 10.01
 	f2.Max = 20.01
 
-	f3 := s.AddMultiField("status")
-	f3.Items = []string{
+	start_date := "09/11/2016 00:00"
+	end_date := "09/11/2016 23:59"
+	f3 := s.AddRangeField("settled-at")
+	f3.Min = start_date
+	f3.Max = end_date
+
+	f4 := s.AddRangeField("created-at")
+	f4.Min = start_date
+
+	f5 := s.AddRangeField("authorization-expired-at")
+	f5.Min = start_date
+
+	f6 := s.AddRangeField("authorized-at")
+	f6.Min = start_date
+
+	f7 := s.AddRangeField("failed-at")
+	f7.Min = start_date
+
+	f8 := s.AddRangeField("gateway-rejected-at")
+	f8.Min = start_date
+
+	f9 := s.AddRangeField("processor-declined-at")
+	f9.Min = start_date
+
+	f10 := s.AddRangeField("submitted-for-settlement-at")
+	f10.Min = start_date
+
+	f11 := s.AddRangeField("voided-at")
+	f11.Min = start_date
+
+	f12 := s.AddRangeField("disbursement-date")
+	f12.Min = start_date
+
+	f13 := s.AddRangeField("dispute-date")
+	f13.Min = start_date
+
+	f14 := s.AddMultiField("status")
+	f14.Items = []string{
 		"authorized",
 		"submitted_for_settlement",
+		"settled",
 	}
 
 	b, err := xml.MarshalIndent(s, "", "  ")
@@ -45,9 +82,44 @@ func TestSearchXMLEncode(t *testing.T) {
     <min>10.01</min>
     <max>20.01</max>
   </amount>
+  <settled-at>
+    <min>09/11/2016 00:00</min>
+    <max>09/11/2016 23:59</max>
+  </settled-at>
+  <created-at>
+    <min>09/11/2016 00:00</min>
+  </created-at>
+  <authorization-expired-at>
+    <min>09/11/2016 00:00</min>
+  </authorization-expired-at>
+  <authorized-at>
+    <min>09/11/2016 00:00</min>
+  </authorized-at>
+  <failed-at>
+    <min>09/11/2016 00:00</min>
+  </failed-at>
+  <gateway-rejected-at>
+    <min>09/11/2016 00:00</min>
+  </gateway-rejected-at>
+  <processor-declined-at>
+    <min>09/11/2016 00:00</min>
+  </processor-declined-at>
+  <submitted-for-settlement-at>
+    <min>09/11/2016 00:00</min>
+  </submitted-for-settlement-at>
+  <voided-at>
+    <min>09/11/2016 00:00</min>
+  </voided-at>
+  <disbursement-date>
+    <min>09/11/2016 00:00</min>
+  </disbursement-date>
+  <dispute-date>
+    <min>09/11/2016 00:00</min>
+  </dispute-date>
   <status type="array">
     <item>authorized</item>
     <item>submitted_for_settlement</item>
+    <item>settled</item>
   </status>
 </search>`
 

--- a/search_test.go
+++ b/search_test.go
@@ -20,41 +20,41 @@ func TestSearchXMLEncode(t *testing.T) {
 	f2.Min = 10.01
 	f2.Max = 20.01
 
-	start_date := "09/11/2016 00:00"
-	end_date := "09/11/2016 23:59"
+	startDate := "09/11/2016 00:00"
+	endDate := "09/11/2016 23:59"
 	f3 := s.AddRangeField("settled-at")
-	f3.Min = start_date
-	f3.Max = end_date
+	f3.Min = startDate
+	f3.Max = endDate
 
 	f4 := s.AddRangeField("created-at")
-	f4.Min = start_date
+	f4.Min = startDate
 
 	f5 := s.AddRangeField("authorization-expired-at")
-	f5.Min = start_date
+	f5.Min = startDate
 
 	f6 := s.AddRangeField("authorized-at")
-	f6.Min = start_date
+	f6.Min = startDate
 
 	f7 := s.AddRangeField("failed-at")
-	f7.Min = start_date
+	f7.Min = startDate
 
 	f8 := s.AddRangeField("gateway-rejected-at")
-	f8.Min = start_date
+	f8.Min = startDate
 
 	f9 := s.AddRangeField("processor-declined-at")
-	f9.Min = start_date
+	f9.Min = startDate
 
 	f10 := s.AddRangeField("submitted-for-settlement-at")
-	f10.Min = start_date
+	f10.Min = startDate
 
 	f11 := s.AddRangeField("voided-at")
-	f11.Min = start_date
+	f11.Min = startDate
 
 	f12 := s.AddRangeField("disbursement-date")
-	f12.Min = start_date
+	f12.Min = startDate
 
 	f13 := s.AddRangeField("dispute-date")
-	f13.Min = start_date
+	f13.Min = startDate
 
 	f14 := s.AddMultiField("status")
 	f14.Items = []string{


### PR DESCRIPTION
Adds transaction search support for `settled_at`, `created_at`, `authorization_expired_at`, `authorized_at`, `failed_at, gateway_rejected_at`, `processor_declined_at`, `submitted_for_settlement_at`, `voided_at`, `disbursement_date`, `dispute_date` (and any other range fields added to the braintree api in the future should work automatically).

I used an empty interface for the RangeField attributes because they were just using floats, which didn't allow for strings. Also because xml doesn't allow tag fields to have the same names and to not break compatibility with people already using this api with float values. 